### PR TITLE
Add onChange handler to TextInput

### DIFF
--- a/FloatingLabel.js
+++ b/FloatingLabel.js
@@ -91,6 +91,7 @@ class FloatingLabel extends Textbox {
                 locals.onChange(value)
                 self._onChangeText.bind(self, value, locals)
               }}
+              onChange={locals.onChangeNative}
               placeholder={placeholderString}
               maxLength={locals.maxLength}
               numberOfLines={locals.numberOfLines}


### PR DESCRIPTION
Following [#168](https://github.com/gcanti/tcomb-form-native/issues/168) of tcomb-form-native, this is very useful and enables adding a simple AutoExpandingTextInput.
