### PR TITLE
Make sure that when we have a value, we also show the label

### DIFF
--- a/FloatingLabel.js
+++ b/FloatingLabel.js
@@ -14,10 +14,14 @@ const Textbox = t.form.Textbox
 class FloatingLabel extends Textbox {
   constructor (props) {
     super(props);
+
+    // run the value through the transformer, because 0 is also a valid input in some cases
+    const hasValue = this.getTransformer().format(props.value)
+
     this.state = {
-      fieldFocused: (props.value) ? true : false,
-      value: (props.value) ? String(props.value) : undefined,
-      fadeAnim: (props.value) ? new Animated.Value(1) : new Animated.Value(0),
+      fieldFocused: hasValue ? true : false,
+      value:  hasValue ? String(props.value) : undefined,
+      fadeAnim: hasValue ? new Animated.Value(1) : new Animated.Value(0),
       placeholderString: undefined,
     };
   }
@@ -25,7 +29,7 @@ class FloatingLabel extends Textbox {
   componentWillReceiveProps(next) {
 
     // Make sure that when we have a value, we also show the label
-    if(this.props.value !== next.value && next.value) {
+    if(this.props.value !== next.value && this.getTransformer().format(next.value)) {
       this.setState({
         fadeAnim: new Animated.Value(1),
       })

--- a/FloatingLabel.js
+++ b/FloatingLabel.js
@@ -22,6 +22,19 @@ class FloatingLabel extends Textbox {
     };
   }
 
+  componentWillReceiveProps(next) {
+
+    // Make sure that when we have a value, we also show the label
+    if(this.props.value !== next.value && next.value) {
+      this.setState({
+        fadeAnim: new Animated.Value(1),
+      })
+    }
+
+    super.componentWillReceiveProps(next)
+  }
+
+
   getTemplate () {
     let self = this
     return function (locals) {


### PR DESCRIPTION
When a user loads a form in our application it's by default empty. However we have a "favorites" feature - the user clicks on previous values and the form is pre-populated with data. This works, but the label was missing as it's set in the constructor to 0 when we don't have a value.

In this pull request I'm comparing the next props and if it has a value I'm setting fadeAnim to true